### PR TITLE
Fix/flavor dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+TODO
+
 # dcluster dev
 .dcluster
 

--- a/dcluster/util/fs.py
+++ b/dcluster/util/fs.py
@@ -80,11 +80,17 @@ def find_files_with_extension(dirpath, extension):
     '''
     list all files in directory (not-recursive) that have an extension, e.g. '.txt'
     '''
-    return [
-        file
-        for file in os.listdir(dirpath)
-        if file.endswith(extension)
-    ]
+    # only for actual dirs
+    files = []
+
+    if os.path.isdir(dirpath):
+        files = [
+            file
+            for file in os.listdir(dirpath)
+            if file.endswith(extension)
+        ]
+
+    return files
 
 
 def check_directories_exist(directories):

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 #SPHINXBUILD   = sphinx-build
-SPHINXBUILD   = python -m sphinx.cmd.build
+SPHINXBUILD   = python3 -m sphinx.cmd.build
 SPHINXPROJ    = dcluster
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
Fixes following error:

```
25-Aug-20 17:44:04 -  DEBUG | places to look for flavors: ['config/flavors', '/home/giacomo/.dcluster/flavors']
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/giacomo/dev/atos/python/dcluster/dcluster/main.py", line 77, in <module>
    processRequest()
  File "/home/giacomo/dev/atos/python/dcluster/dcluster/main.py", line 68, in processRequest
    args.func(args)
  File "dcluster/cli/create.py", line 54, in process_cli_call
    create_action.create_basic_cluster(creation_request)
  File "dcluster/actions/create.py", line 25, in create_basic_cluster
    cluster_plan = cluster.create_plan(creation_request, cluster_network)
  File "dcluster/cluster/__init__.py", line 22, in create_plan
    creation_request.flavor_paths)
  File "dcluster/config/flavor_config.py", line 108, in cluster_config_for_flavor
    available_flavors = all_available_flavors(user_places_to_look)
  File "dcluster/config/flavor_config.py", line 21, in all_available_flavors
    __all_flavors__ = get_all_available_flavors(user_places_to_look)
  File "dcluster/config/flavor_config.py", line 39, in get_all_available_flavors
    candidate_yaml_files = find_candidate_yaml_files(user_places_to_look)
  File "dcluster/config/flavor_config.py", line 95, in find_candidate_yaml_files
    with_yml = fs.find_files_with_extension(place_to_look, '.yml')
  File "dcluster/util/fs.py", line 85, in find_files_with_extension
    for file in os.listdir(dirpath)
OSError: [Errno 2] No such file or directory: '/home/giacomo/.dcluster/flavors'
```