### PR TITLE
Feature/ssh server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,62 @@
 
 * Creates a docker network, ensures that the network subnet is available.
 * Uses a template to create a Dockerfile for docker-compose, then calls docker-compose to instantiate containers attached to the docker network.
+* The containers are spinned up with an SSH server and tini (--init) for proper zombie process reaping.
 * Can choose a cluster "flavor" from existing templates at /usr/share/dcluster/flavors.
-* The cluster "flavors" can be customized and extended to use specific containers and environment variables. The user may add more flavors.
+* The cluster "flavors" can be customized and extended to use specific containers and environment variables. The user may add more cluster flavors.
+
+## Requirements
+
+* Docker 17.06.0+
+
+* docker-compose 1.25.0+ with template 3.7 (support for 'init' variable)
+
+  ```sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -m)" -o /usr/bin/docker-compose && chmod +x /usr/bin/docker-compose```
+
+* docker python API 4.0.0+
+
+  ```pip install --user docker```
+
+Note: use ```dcluster init``` to attempt to download docker API and docker-compose automatically.
+
+## Limitations
+
+* Tested only on CentOS 7 and CentOS 8 (Fedora and RHEL should work), also not in a clean environment yet (TODO try this in a clean VM!)
+  The default packaging (non-RPM) is not supported yet!
+
+* The RPMs can be installed but not all requirements are met. dcluster also requires docker API (pip install docker) and docker-compose.
+  As a workaround, dcluster can try to install these additional requirements (requires internet access) using:
+  ```
+  dcluster init
+  ```
+
+* The container image requires an installation of an SSH server that supports root access (PermitRootLogin yes).
+  Here is an example to install the SSH server for a base CentOS image.
+  From the host, create a container based on a base CentOS image (7.7 as example):
+  ```
+  docker run -it --name dcluster-with-ssh centos:7.7.1908
+  ```
+
+  This should open the container terminal, install SSH server and create host keys:
+  ```
+  yum install -y openssh-server
+  ssh-keygen -A
+  ```
+
+  Commit this image to docker in the host and clean up:
+  ```
+  docker commit dcluster-with-ssh centos:7.7.1908-ssh
+  docker stop dcluster-with-ssh
+  docker rm dcluster-with-ssh
+  ```
+
+* The default flavor (simple) is pointing to centos:7.7.1908-ssh, which immediately fails if this image is not available. TODO let this be a variable managed by configuration, and that the user can override using --image
+
+* User-provided Ansible playbooks will be supported very soon...
 
 ## Usage
+
+Note: Read the limitations and requirements before trying it out!
 
 * Create a cluster of 2 compute nodes identified by "my\_cluster":
 
@@ -38,21 +90,6 @@
 * Remove a cluster (will remove containers and  the network):
 
   ```dcluster rm my_cluster```
-
-## Requirements
-
-* Docker 17.06.0+
-
-* docker-compose 1.25.0+
-
-  ```sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -m)" -o /usr/bin/docker-compose && chmod +x /usr/bin/docker-compose```
-
-  
-* docker python API 4.0.0+
-
-  ```pip install --user docker```
-
-Note: use ```dcluster init``` to attempt to download docker API and docker-compose automatically.
 
 ## Running the tests
 
@@ -84,6 +121,8 @@ You may need to install requirements for setup beforehand, using
 ```bash
 pip install --user -r deployment/requirements.txt
 ```
+
+Note: more requirements may be missing, TODO!
 
 ## Generating the documentation page
 

--- a/config/flavors/simple.yml
+++ b/config/flavors/simple.yml
@@ -4,10 +4,10 @@ simple:
 
   head:
     hostname: 'head'
-    image: 'centos7:ssh'
+    image: 'centos:7.7.1908-ssh'
 
   compute:
     hostname:
         prefix: 'node'
         suffix_len: 3          
-    image:  'centos7:ssh'
+    image:  'centos:7.7.1908-ssh'

--- a/dcluster/cluster/blueprint.py
+++ b/dcluster/cluster/blueprint.py
@@ -27,6 +27,13 @@ class ClusterBlueprint(logger.LoggerMixin):
         cluster_definition = renderer.render_blueprint(self.as_dict(), template)
         deployer.deploy(cluster_definition)
 
+        # check for containers
+        if deployer.a_container_has_exited():
+
+            # a container has exited, not what we want
+            deployer.show_logs()
+            raise ValueError('A container failed to start, see output')
+
         log_msg = 'Docker cluster %s -  %s created!'
         self.logger.info(log_msg % (self.name, self.cluster_network))
 

--- a/dcluster/runtime/deploy.py
+++ b/dcluster/runtime/deploy.py
@@ -47,3 +47,26 @@ class DockerComposeDeployer(logger.LoggerMixin):
         if run[2] or run[0]:
             # return code is different than 0, something went wrong
             raise ComposeFailure('docker-compose command failed, check output')
+
+    def a_container_has_exited(self):
+        '''
+        Calls docker-compose ps to check if a container has already exited
+        Returns True iff a container has exited, the output is saved as ps_stdout member variable.
+        '''
+        # run docker-compose ps, save output
+        cmd = 'docker-compose -f docker-cluster.yml ps'
+        run = runit.execute(cmd, cwd=self.compose_path)
+        self.ps_stdout = run[0]
+
+        # look for 'Exit'
+        return 'Exit' in self.ps_stdout
+
+    def show_logs(self):
+        '''
+        Prints the docker-compose logs to the screen.
+        '''
+        # run docker-compose logs
+        cmd = 'docker-compose -f docker-cluster.yml logs'
+        run = runit.execute(cmd, cwd=self.compose_path)
+
+        print(run[0])

--- a/dcluster/runtime/deploy.py
+++ b/dcluster/runtime/deploy.py
@@ -42,7 +42,8 @@ class DockerComposeDeployer(logger.LoggerMixin):
 
         # always show the output of the docker-compose call
         print(run[1])
+        print(run[0])
 
-        if run[2]:
+        if run[2] or run[0]:
             # return code is different than 0, something went wrong
             raise ComposeFailure('docker-compose command failed, check output')

--- a/templates/cluster-basic.yml.j2
+++ b/templates/cluster-basic.yml.j2
@@ -1,10 +1,12 @@
-version: '3.3'
+version: '3.7'
 services:
 {% for node_ip, node in nodes.items() | sort(attribute='1.hostname') %}
 
     {{node.container}}:
         container_name: {{node.container}}
         image: {{node.image}}
+        init: true
+        entrypoint: ["/bin/bash", "-c", "/sbin/sshd -D 2> /dev/null || /usr/sbin/sshd -D 2> /dev/null || echo \"dcluster needs SSH server installed in image\""]
         hostname: {{node.hostname}}
         labels:
             bull.com.dcluster.role: {{node.role}}


### PR DESCRIPTION
dcluster had an undocumented limitation: the containers were spinned up with supervisor as the entrypoint, which was running an SSH server. This PR alleviates this limitation using tini (--init), the new requirements (or limitations) are as follows:

- The image needs to have a SSH server installed (either /sbin/sshd or /usr/sbin/sshd)
- docker-compose must support template version 3.7, which includes init

The PR also improves documentation regarding this issue in the README. 