### PR TITLE
Use /sbin/init and SYS_ADMIN cap to enable systemctl on containers when systemctl=True

### DIFF
--- a/config/flavors/rhel82.yml
+++ b/config/flavors/rhel82.yml
@@ -1,0 +1,10 @@
+---
+
+rhel82-ssh:
+  extend: simple
+
+  head:
+    image: 'rhel82:ssh'
+
+  compute:
+    image: 'rhel82:ssh'

--- a/config/flavors/simple.yml
+++ b/config/flavors/simple.yml
@@ -11,3 +11,12 @@ simple:
         prefix: 'node'
         suffix_len: 3          
     image:  'centos:7.7.1908'
+
+simple-systemctl:
+  extend: simple
+  head:
+    systemctl: true
+    image: 'centos:7.7.1908-init'
+  compute:
+    systemctl: true
+    image: 'centos:7.7.1908-init'

--- a/dcluster/actions/create.py
+++ b/dcluster/actions/create.py
@@ -56,6 +56,9 @@ def create_default_cluster(creation_request):
         for public_key_path in public_key_paths:
             live_cluster.inject_public_ssh_key(public_key_path)
 
+    # fix for containers running /sbin/init
+    live_cluster.fix_init_if_needed()
+
     # run requested Ansible playbooks with optional extra vars
     for playbook in creation_request.playbooks:
         dansible.run_playbook(cluster_name, playbook, inventory_file,

--- a/dcluster/cluster/instance.py
+++ b/dcluster/cluster/instance.py
@@ -136,6 +136,15 @@ class RunningClusterMixin(logger.LoggerMixin):
         for n in self.ordered_nodes:
             n.inject_public_ssh_key(ssh_target_path, public_key)
 
+    def fix_init_if_needed(self):
+        '''
+        If a container is using "/sbin/init" as an entrypoint, we need to perform some actions
+        after creating the instance.
+        '''
+        for n in self.ordered_nodes:
+            if n.needs_init_fix:
+                n.run_init_fix()
+
 
 class DeployedCluster(ClusterBlueprint, RunningClusterMixin):
     '''

--- a/dcluster/infra/docker_facade.py
+++ b/dcluster/infra/docker_facade.py
@@ -160,6 +160,11 @@ class DockerContainers:
 
         return role
 
+    @classmethod
+    def has_sys_admin_cap(cls, docker_container):
+        cap_adds = docker_container.attrs['HostConfig']['CapAdd']
+        return isinstance(cap_adds, list) and 'SYS_ADMIN' in cap_adds
+
 
 class DockerNetworking:
     '''

--- a/dcluster/node/__init__.py
+++ b/dcluster/node/__init__.py
@@ -6,4 +6,4 @@ BasicPlannedNode = namedtuple('BasicPlannedNode', 'hostname, container, image, i
 
 # node details for the 'default' plan when creating a cluster
 DefaultPlannedNode = namedtuple('DefaultPlannedNode', 'hostname, container, image, ip_address, \
-						         role, volumes, static_text')
+                                role, volumes, static_text, systemctl')

--- a/dcluster/node/instance.py
+++ b/dcluster/node/instance.py
@@ -88,6 +88,21 @@ class DeployedNode(logger.LoggerMixin):
 
         self.docker_container.exec_run(run_cmd)
 
+    def needs_init_fix(self):
+        return DockerContainers.has_sys_admin_cap(self.docker_container)
+
+    def run_init_fix(self):
+        '''
+        If the container is using "/sbin/init" as an entrypoint, we need to remove the /var/run/nologin
+        file, otherwise can run into problems with SSH.
+        '''
+        run_cmd = '/bin/bash -c "rm -f /var/run/nologin"'
+
+        log_msg = 'Run init fix in docker container %s: %s'
+        self.logger.debug(log_msg % (self.docker_container.name, run_cmd))
+
+        self.docker_container.exec_run(run_cmd)
+
     def __str__(self):
         return 'DeployedNode: {}->{}'.format(self.planned.image, self.planned.hostname)
 

--- a/dcluster/node/planner.py
+++ b/dcluster/node/planner.py
@@ -113,4 +113,9 @@ class DefaultNodePlanner(BasicNodePlanner):
         extended_dict['volumes'] = volumes
         extended_dict['static_text'] = static_text
 
+        # will container run systemctl?
+        extended_dict['systemctl'] = False
+        if plan_data[role].get('systemctl', False):
+            extended_dict['systemctl'] = True
+
         return DefaultPlannedNode(**extended_dict)

--- a/dcluster/runtime/deploy.py
+++ b/dcluster/runtime/deploy.py
@@ -34,7 +34,6 @@ class DockerComposeDeployer(logger.LoggerMixin):
         # note: apparently, using docker-compose.yml and removing '-f' fails to
         # to acknowledge the --force-recreate option
         #
-        # TODO think about privileged containers
         cmd = 'docker-compose --no-ansi -f docker-cluster.yml up -d --force-recreate'
         run = runit.execute(cmd, cwd=self.compose_path, env=os.environ)
 

--- a/dcluster/tests/cluster/test_planner.py
+++ b/dcluster/tests/cluster/test_planner.py
@@ -40,11 +40,12 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 '172.30.0.253': DefaultPlannedNode(
                     hostname='head',
                     container='mycluster-head',
-                    image='centos:7.7.1908-ssh',
+                    image='centos:7.7.1908',
                     ip_address='172.30.0.253',
                     role='head',
                     volumes=[],
-                    static_text=''),
+                    static_text='',
+                    systemctl=False),
             },
             'network': {
                 'name': 'dcluster-mycluster',
@@ -53,7 +54,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 'gateway_ip': '172.30.0.254'
             },
             'template': 'cluster-default.yml.j2',
-            'volumes': []
+            'volumes': [],
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
         }
         self.assertEqual(result, expected)
 
@@ -78,11 +80,12 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 '172.30.1.125': DefaultPlannedNode(
                     hostname='head',
                     container='mycluster-head',
-                    image='centos:7.7.1908-ssh',
+                    image='centos:7.7.1908',
                     ip_address='172.30.1.125',
                     role='head',
                     volumes=[],
-                    static_text=''),
+                    static_text='',
+                    systemctl=False),
             },
             'network': {
                 'name': 'dcluster-mycluster',
@@ -91,7 +94,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 'gateway_ip': '172.30.1.126'
             },
             'template': 'cluster-default.yml.j2',
-            'volumes': []
+            'volumes': [],
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
         }
         self.assertEqual(result, expected)
 
@@ -116,19 +120,21 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 '172.30.0.253': DefaultPlannedNode(
                     hostname='head',
                     container='mycluster-head',
-                    image='centos:7.7.1908-ssh',
+                    image='centos:7.7.1908',
                     ip_address='172.30.0.253',
                     role='head',
                     volumes=[],
-                    static_text=''),
+                    static_text='',
+                    systemctl=False),
                 '172.30.0.1': DefaultPlannedNode(
                     hostname='node001',
                     container='mycluster-node001',
-                    image='centos:7.7.1908-ssh',
+                    image='centos:7.7.1908',
                     ip_address='172.30.0.1',
                     role='compute',
                     volumes=[],
-                    static_text=''),
+                    static_text='',
+                    systemctl=False),
             },
             'network': {
                 'name': 'dcluster-mycluster',
@@ -137,7 +143,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 'gateway_ip': '172.30.0.254'
             },
             'template': 'cluster-default.yml.j2',
-            'volumes': []
+            'volumes': [],
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
         }
         self.assertEqual(result, expected)
 
@@ -162,35 +169,39 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 '172.30.0.253': DefaultPlannedNode(
                     hostname='head',
                     container='mycluster-head',
-                    image='centos:7.7.1908-ssh',
+                    image='centos:7.7.1908',
                     ip_address='172.30.0.253',
                     role='head',
                     volumes=[],
-                    static_text=''),
+                    static_text='',
+                    systemctl=False),
                 '172.30.0.1': DefaultPlannedNode(
                     hostname='node001',
                     container='mycluster-node001',
-                    image='centos:7.7.1908-ssh',
+                    image='centos:7.7.1908',
                     ip_address='172.30.0.1',
                     role='compute',
                     volumes=[],
-                    static_text=''),
+                    static_text='',
+                    systemctl=False),
                 '172.30.0.2': DefaultPlannedNode(
                     hostname='node002',
                     container='mycluster-node002',
-                    image='centos:7.7.1908-ssh',
+                    image='centos:7.7.1908',
                     ip_address='172.30.0.2',
                     role='compute',
                     volumes=[],
-                    static_text=''),
+                    static_text='',
+                    systemctl=False),
                 '172.30.0.3': DefaultPlannedNode(
                     hostname='node003',
                     container='mycluster-node003',
-                    image='centos:7.7.1908-ssh',
+                    image='centos:7.7.1908',
                     ip_address='172.30.0.3',
                     role='compute',
                     volumes=[],
-                    static_text='')
+                    static_text='',
+                    systemctl=False)
             },
             'network': {
                 'name': 'dcluster-mycluster',
@@ -199,7 +210,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 'gateway_ip': '172.30.0.254'
             },
             'template': 'cluster-default.yml.j2',
-            'volumes': []
+            'volumes': [],
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
         }
         self.assertEqual(result, expected)
 
@@ -247,7 +259,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
         expose:
           - '6817'
           - '6819'
-      '''),
+      ''',
+                    systemctl=False),
                 '172.30.0.1': DefaultPlannedNode(
                     hostname='node001',
                     container='mycluster-node001',
@@ -268,7 +281,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
         expose:
           - '6818'
         shm_size: 4g
-      '''),
+      ''',
+                    systemctl=False),
                 '172.30.0.2': DefaultPlannedNode(
                     hostname='node002',
                     container='mycluster-node002',
@@ -289,7 +303,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
         expose:
           - '6818'
         shm_size: 4g
-      '''),
+      ''',
+                    systemctl=False),
                 '172.30.0.3': DefaultPlannedNode(
                     hostname='node003',
                     container='mycluster-node003',
@@ -310,7 +325,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
         expose:
           - '6818'
         shm_size: 4g
-      ''')
+      ''',
+                    systemctl=False)
             },
             'network': {
                 'name': 'dcluster-mycluster',
@@ -325,7 +341,8 @@ class TestBuildSpecsOfDefaultClusterPlan(unittest.TestCase):
                 'etc_slurm',
                 'slurm_jobdir',
                 'var_log_slurm'
-            ]
+            ],
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
         }
         self.assertEqual(result, expected)
 
@@ -350,14 +367,14 @@ class TestCreateDefaultClusterPlan(unittest.TestCase):
             'name': 'test',
             'head': {
                 'hostname': 'head',
-                'image': 'centos:7.7.1908-ssh'
+                'image': 'centos:7.7.1908'
             },
             'compute': {
                 'hostname': {
                     'prefix': 'node',
                     'suffix_len': 3
                 },
-                'image': 'centos:7.7.1908-ssh'
+                'image': 'centos:7.7.1908'
             },
             'network': cluster_network.as_dict(),
             'template': 'cluster-default.yml.j2'

--- a/dcluster/tests/node/test_planner_basic.py
+++ b/dcluster/tests/node/test_planner_basic.py
@@ -53,8 +53,8 @@ class CreateBasicComputeNode(unittest.TestCase):
 
         # then
         expected = BasicPlannedNode(hostname='node002',
-                                     container='mycluster-node002',
-                                     image='centos:7.7.1908-ssh',
-                                     ip_address='172.30.0.2',
-                                     role='compute')
+                                    container='mycluster-node002',
+                                    image='centos:7.7.1908',
+                                    ip_address='172.30.0.2',
+                                    role='compute')
         self.assertEqual(result, expected)

--- a/dcluster/tests/node/test_planner_extended.py
+++ b/dcluster/tests/node/test_planner_extended.py
@@ -51,6 +51,7 @@ class CreateExtendedHeadPlan(unittest.TestCase):
                 'etc_slurm:/etc/slurm',
                 'slurm_jobdir:/data',
                 'var_log_slurm:/var/log/slurm'
-            ]
+            ],
+            'systemctl': False
         }
         self.assertEqual(dict(result._asdict()), expected)

--- a/dcluster/tests/resources/compose-with-static.yaml
+++ b/dcluster/tests/resources/compose-with-static.yaml
@@ -1,6 +1,8 @@
     mycluster-head:
         container_name: mycluster-head
         image: centos7:slurmctld
+        init: true
+        entrypoint: "/dcluster/bootstrap.sh"
         hostname: head
         networks:
             dcluster-mycluster:

--- a/dcluster/tests/resources/docker-compose-extended-simplified.yml
+++ b/dcluster/tests/resources/docker-compose-extended-simplified.yml
@@ -5,7 +5,7 @@ services:
         container_name: mycluster-head
         image: centos7:slurmctld
         init: true
-        entrypoint: ["/bin/bash", "-c", "/sbin/sshd -D 2> /dev/null || /usr/sbin/sshd -D 2> /dev/null || echo \"dcluster needs SSH server installed in image\""]
+        entrypoint: "/dcluster/bootstrap.sh"
         hostname: head
         labels:
             bull.com.dcluster.role: head
@@ -17,13 +17,15 @@ services:
             node001: 172.30.0.1
             node002: 172.30.0.2
             gateway: 172.30.0.254
+        volumes:
+            - /home/giacomo/dcluster/bootstrap:/dcluster
 
 
     mycluster-node001:
         container_name: mycluster-node001
         image: centos7:slurmd
         init: true
-        entrypoint: ["/bin/bash", "-c", "/sbin/sshd -D 2> /dev/null || /usr/sbin/sshd -D 2> /dev/null || echo \"dcluster needs SSH server installed in image\""]
+        entrypoint: "/dcluster/bootstrap.sh"
         hostname: node001
         labels:
             bull.com.dcluster.role: compute
@@ -35,13 +37,15 @@ services:
             node001: 172.30.0.1
             node002: 172.30.0.2
             gateway: 172.30.0.254
+        volumes:
+            - /home/giacomo/dcluster/bootstrap:/dcluster
 
 
     mycluster-node002:
         container_name: mycluster-node002
         image: centos7:slurmd
         init: true
-        entrypoint: ["/bin/bash", "-c", "/sbin/sshd -D 2> /dev/null || /usr/sbin/sshd -D 2> /dev/null || echo \"dcluster needs SSH server installed in image\""]
+        entrypoint: "/dcluster/bootstrap.sh"
         hostname: node002
         labels:
             bull.com.dcluster.role: compute
@@ -53,6 +57,8 @@ services:
             node001: 172.30.0.1
             node002: 172.30.0.2
             gateway: 172.30.0.254
+        volumes:
+            - /home/giacomo/dcluster/bootstrap:/dcluster
 
 
 networks:

--- a/dcluster/tests/resources/docker-compose-simple-priv.yml
+++ b/dcluster/tests/resources/docker-compose-simple-priv.yml
@@ -4,8 +4,10 @@ services:
     mycluster-head:
         container_name: mycluster-head
         image: centos7:ssh
-        init: true
-        entrypoint: "/dcluster/bootstrap.sh"
+        init: false
+        entrypoint: "/sbin/init"
+        cap_add:
+            - SYS_ADMIN
         hostname: head
         labels:
             bull.com.dcluster.role: head
@@ -19,13 +21,16 @@ services:
             gateway: 172.30.0.254
         volumes:
             - /home/giacomo/dcluster/bootstrap:/dcluster
+            - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 
     mycluster-node001:
         container_name: mycluster-node001
         image: centos7:ssh
-        init: true
-        entrypoint: "/dcluster/bootstrap.sh"
+        init: false
+        entrypoint: "/sbin/init"
+        cap_add:
+            - SYS_ADMIN
         hostname: node001
         labels:
             bull.com.dcluster.role: compute
@@ -39,13 +44,16 @@ services:
             gateway: 172.30.0.254
         volumes:
             - /home/giacomo/dcluster/bootstrap:/dcluster
+            - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 
     mycluster-node002:
         container_name: mycluster-node002
         image: centos7:ssh
-        init: true
-        entrypoint: "/dcluster/bootstrap.sh"
+        init: false
+        entrypoint: "/sbin/init"
+        cap_add:
+            - SYS_ADMIN
         hostname: node002
         labels:
             bull.com.dcluster.role: compute
@@ -59,6 +67,7 @@ services:
             gateway: 172.30.0.254
         volumes:
             - /home/giacomo/dcluster/bootstrap:/dcluster
+            - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 
 networks:

--- a/dcluster/tests/resources/docker-compose-slurm.yml
+++ b/dcluster/tests/resources/docker-compose-slurm.yml
@@ -5,7 +5,7 @@ services:
         container_name: mycluster-head
         image: centos7:slurmctld
         init: true
-        entrypoint: ["/bin/bash", "-c", "/sbin/sshd -D 2> /dev/null || /usr/sbin/sshd -D 2> /dev/null || echo \"dcluster needs SSH server installed in image\""]
+        entrypoint: "/dcluster/bootstrap.sh"
         hostname: head
         labels:
             bull.com.dcluster.role: head
@@ -18,6 +18,7 @@ services:
             node002: 172.30.0.2
             gateway: 172.30.0.254
         volumes:
+            - /home/giacomo/dcluster/bootstrap:/dcluster
             - /home:/home
             - /opt/intel:/opt/intel
             - /srv/shared:/srv/dcluster/shared
@@ -39,7 +40,7 @@ services:
         container_name: mycluster-node001
         image: centos7:slurmd
         init: true
-        entrypoint: ["/bin/bash", "-c", "/sbin/sshd -D 2> /dev/null || /usr/sbin/sshd -D 2> /dev/null || echo \"dcluster needs SSH server installed in image\""]
+        entrypoint: "/dcluster/bootstrap.sh"
         hostname: node001
         labels:
             bull.com.dcluster.role: compute
@@ -52,6 +53,7 @@ services:
             node002: 172.30.0.2
             gateway: 172.30.0.254
         volumes:
+            - /home/giacomo/dcluster/bootstrap:/dcluster
             - /home:/home
             - /opt/intel:/opt/intel
             - /srv/shared:/srv/dcluster/shared
@@ -67,7 +69,7 @@ services:
         container_name: mycluster-node002
         image: centos7:slurmd
         init: true
-        entrypoint: ["/bin/bash", "-c", "/sbin/sshd -D 2> /dev/null || /usr/sbin/sshd -D 2> /dev/null || echo \"dcluster needs SSH server installed in image\""]
+        entrypoint: "/dcluster/bootstrap.sh"
         hostname: node002
         labels:
             bull.com.dcluster.role: compute
@@ -80,6 +82,7 @@ services:
             node002: 172.30.0.2
             gateway: 172.30.0.254
         volumes:
+            - /home/giacomo/dcluster/bootstrap:/dcluster
             - /home:/home
             - /opt/intel:/opt/intel
             - /srv/shared:/srv/dcluster/shared

--- a/dcluster/tests/runtime/test_renderer.py
+++ b/dcluster/tests/runtime/test_renderer.py
@@ -46,7 +46,8 @@ class TestJinjaRenderer(unittest.TestCase):
                 'address': '172.30.0.0/24',
                 'gateway': 'gateway',
                 'gateway_ip': '172.30.0.254'
-            }
+            },
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
         }
         template_filename = 'cluster-default.yml.j2'
 
@@ -55,6 +56,52 @@ class TestJinjaRenderer(unittest.TestCase):
 
         # then matches a saved file
         expected = self.resources.expected_docker_compose_simple
+        self.assertEqual(result, expected)
+
+    def test_basic_render_with_systemctl(self):
+        # given a basic cluster specification but systemctl=True
+        cluster_specs = {
+            'nodes': {
+                '172.30.0.253': {
+                    'hostname': 'head',
+                    'container': 'mycluster-head',
+                    'image': 'centos7:ssh',
+                    'ip_address': '172.30.0.253',
+                    'role': 'head',
+                    'systemctl': True
+                },
+                '172.30.0.1': {
+                    'hostname': 'node001',
+                    'container': 'mycluster-node001',
+                    'image': 'centos7:ssh',
+                    'ip_address': '172.30.0.1',
+                    'role': 'compute',
+                    'systemctl': True
+                },
+                '172.30.0.2': {
+                    'hostname': 'node002',
+                    'container': 'mycluster-node002',
+                    'image': 'centos7:ssh',
+                    'ip_address': '172.30.0.2',
+                    'role': 'compute',
+                    'systemctl': True
+                }
+            },
+            'network': {
+                'name': 'dcluster-mycluster',
+                'address': '172.30.0.0/24',
+                'gateway': 'gateway',
+                'gateway_ip': '172.30.0.254'
+            },
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
+        }
+        template_filename = 'cluster-default.yml.j2'
+
+        # when
+        result = self.renderer.render_blueprint(cluster_specs, template_filename)
+
+        # then matches a saved file
+        expected = self.resources.expected_docker_compose_simple_priv
         self.assertEqual(result, expected)
 
     def test_slurm_render(self):
@@ -138,6 +185,7 @@ class TestJinjaRenderer(unittest.TestCase):
                 'var_lib_mysql',
                 'var_log_slurm'
             ],
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
         }
         template_filename = 'cluster-default.yml.j2'
 
@@ -180,6 +228,7 @@ class TestJinjaRenderer(unittest.TestCase):
                 'gateway': 'gateway',
                 'gateway_ip': '172.30.0.254'
             },
+            'bootstrap_dir': '/home/giacomo/dcluster/bootstrap'
         }
         template_filename = 'cluster-default.yml.j2'
 

--- a/dcluster/tests/test_resources.py
+++ b/dcluster/tests/test_resources.py
@@ -26,6 +26,10 @@ class ResourcesForTest(object):
         return self.read_text_file('docker-compose-simple.yml')
 
     @property
+    def expected_docker_compose_simple_priv(self):
+        return self.read_text_file('docker-compose-simple-priv.yml')
+
+    @property
     def expected_docker_compose_slurm(self):
         return self.read_text_file('docker-compose-slurm.yml')
 

--- a/templates/cluster-default.yml.j2
+++ b/templates/cluster-default.yml.j2
@@ -5,8 +5,17 @@ services:
     {{node.container}}:
         container_name: {{node.container}}
         image: {{node.image}}
+{% if node.systemctl %}
+{#      Using privileged: true messes with the host's GUI, so just adding SYS_ADMIN cap instead #}
+        init: false
+        entrypoint: "/sbin/init"
+        cap_add:
+            - SYS_ADMIN
+{% else %}
+{#      Here we allow docker's init as PID 0 which will call our bootstrap script #}
         init: true
         entrypoint: "/dcluster/bootstrap.sh"
+{% endif %}
         hostname: {{node.hostname}}
         labels:
             bull.com.dcluster.role: {{node.role}}
@@ -20,6 +29,10 @@ services:
             gateway: {{network.gateway_ip}}
         volumes:
             - {{bootstrap_dir}}:/dcluster
+{% if node.systemctl %}
+{# this mount is required for systemctl to work #}
+            - /sys/fs/cgroup:/sys/fs/cgroup:ro
+{% endif %}
 {% if node.volumes %}
 {% for node_volume in node.volumes %}
             - {{node_volume}}


### PR DESCRIPTION
Closes #14 : not really supporting privileged containers because of issues with the GUI when creating privileged containers. What we really need is to support systemctl, so this PR will support systemctl by:
- running /sbin/init at PID 0
- adding SYS_ADMIN cap
- mounting /sys/fs/cgroup:/sys/fs/cgroup:ro